### PR TITLE
ci: change ports and add top-level docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 [![Review Assignment Due Date](https://classroom.github.com/assets/deadline-readme-button-24ddc0f5d75046c5622901739e7c5dd533143b0c8e959d652212380cedb1ea36.svg)](https://classroom.github.com/a/6BOvYMwN)
+
 # AssignmentTemplate
+
+## Instructions to run
+
+### Pre-requisites
+
+- Ensure you have Docker Desktop (>= v4.22.\*) installed (https://docs.docker.com/desktop/install/mac-install/)

--- a/backend/api-gateway/app/Dockerfile
+++ b/backend/api-gateway/app/Dockerfile
@@ -12,5 +12,5 @@ WORKDIR /usr/src/app
 COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev
 COPY --from=builder ./usr/src/app/dist ./dist
-EXPOSE 80
+EXPOSE 8080
 CMD ["npm", "run", "start"]

--- a/backend/api-gateway/app/Dockerfile.dev
+++ b/backend/api-gateway/app/Dockerfile.dev
@@ -8,6 +8,6 @@ COPY package.json package-lock.json* ./
 RUN npm install
 COPY . .
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["npm", "run", "dev"]

--- a/backend/api-gateway/app/docker-compose.yml
+++ b/backend/api-gateway/app/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3"
 
 services:
-  app:
+  api-gateway:
     build:
       context: .
       dockerfile: Dockerfile.dev
     volumes:
       - ./:/usr/src/app
     ports:
-      - "80:80"
+      - "8000:8080"

--- a/backend/api-gateway/app/index.ts
+++ b/backend/api-gateway/app/index.ts
@@ -6,12 +6,12 @@ import { createProxyMiddleware } from "http-proxy-middleware";
 dotenv.config();
 
 const app: Application = express();
-const PORT = process.env.PORT || 80;
+const PORT = process.env.PORT || 8080;
 const USERS_SERVICE_URL =
   process.env.USERS_SERVICE_URL || "http://localhost:8001";
 
 app.get("/", (req: Request, res: Response) => {
-  res.send("Welcome to PeerPrep!!");
+  res.send("Welcome to PeerPrep!!!");
 });
 
 app.use(

--- a/backend/api-gateway/infra/Pulumi.master.yaml
+++ b/backend/api-gateway/infra/Pulumi.master.yaml
@@ -1,5 +1,6 @@
 config:
-  api-gateway-infra:containerPort: "80"
+  api-gateway-infra:hostPort: "80"
+  api-gateway-infra:containerPort: "8080"
   api-gateway-infra:cpu: "512"
   api-gateway-infra:memory: "128"
   api-gateway-infra:path: ../app

--- a/backend/api-gateway/infra/Pulumi.staging.yaml
+++ b/backend/api-gateway/infra/Pulumi.staging.yaml
@@ -1,5 +1,6 @@
 config:
-  api-gateway-infra:containerPort: "80"
+  api-gateway-infra:hostPort: "80"
+  api-gateway-infra:containerPort: "8080"
   api-gateway-infra:cpu: "512"
   api-gateway-infra:memory: "128"
   api-gateway-infra:path: ../app

--- a/backend/api-gateway/infra/index.ts
+++ b/backend/api-gateway/infra/index.ts
@@ -3,7 +3,8 @@ import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
 
 const config = new pulumi.Config();
-const containerPort = config.getNumber("containerPort") || 80;
+const hostPort = config.getNumber("hostPort") || 80;
+const containerPort = config.getNumber("containerPort") || 8080;
 const cpu = config.getNumber("cpu") || 512;
 const memory = config.getNumber("memory") || 128;
 
@@ -37,6 +38,7 @@ const service = new awsx.ecs.FargateService("service", {
       essential: true,
       portMappings: [
         {
+          hostPort: hostPort,
           containerPort: containerPort,
           targetGroup: loadbalancer.defaultTargetGroup,
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,3 @@
+version: "3"
+include:
+  - ./backend/api-gateway/app/docker-compose.yml


### PR DESCRIPTION
1. Change `docker-compose.dev.yml` (which invokes `Dockerfile.dev`) `hostPort` to `8000`. So all the services can be on sequential ports (e.g. API Gateway can be `8000`, User service `8001`, etc.)
    - And when deployed onto ECS, they should all be exposed at port `80` for HTTP
2. add a top-level `docker-compose.yml` file to run all services at once