### PR TITLE
feat: run matching service ws thru api gateway and fix inter container comms

### DIFF
--- a/backend/api-gateway/app/.env.example
+++ b/backend/api-gateway/app/.env.example
@@ -9,7 +9,8 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 GITHUB_CALLBACK_URL=http://localhost:8000/github/callback
 
-USERS_SERVICE_URL=http://localhost:8002
-QUESTIONS_SERVICE_URL=http://localhost:8003
-MATCHING_SERVICE_URL=http://localhost:8004
-COLLABORATION_SERVICE_URL=http://localhost:8005
+# These are the service names defined in docker-compose.yml (for inter-container communication)
+USERS_SERVICE_URL=http://users-service
+QUESTIONS_SERVICE_URL=http://questions-service
+MATCHING_SERVICE_URL=http://matching-service
+COLLABORATION_SERVICE_URL=http://collaboration-service

--- a/backend/api-gateway/app/index.ts
+++ b/backend/api-gateway/app/index.ts
@@ -9,11 +9,6 @@ if (process.env.NODE_ENV === "development") {
 }
 const envServerParsed = envSchema.safeParse(process.env);
 if (!envServerParsed.success) {
-  console.log(
-    "These were the provided environment variables",
-    JSON.stringify(process.env)
-  );
-  console.error(envServerParsed.error.issues);
   throw new Error("There is an error with the server environment variables");
 }
 process.env = envServerParsed.data;

--- a/backend/api-gateway/app/libs/middleware.ts
+++ b/backend/api-gateway/app/libs/middleware.ts
@@ -40,12 +40,10 @@ export const adminMiddleware: RequestHandler = async (req, res, next) => {
   if (userData.roles && userData.roles.includes(ROLE.ADMIN)) {
     next();
   } else {
-    return res
-      .status(HTTP_STATUS_CODE.UNAUTHORIZED)
-      .send(
-        failApiResponse({
-          message: "User is not authorized to perform this action",
-        })
-      );
+    return res.status(HTTP_STATUS_CODE.UNAUTHORIZED).send(
+      failApiResponse({
+        message: "User is not authorized to perform this action",
+      })
+    );
   }
 };

--- a/backend/api-gateway/app/types/env.ts
+++ b/backend/api-gateway/app/types/env.ts
@@ -26,10 +26,13 @@ export const envSchema = z.object({
   /**
    * For services
    */
-  USERS_SERVICE_URL: z.string().url().default("http://localhost:8002"),
-  QUESTIONS_SERVICE_URL: z.string().url().default("http://localhost:8003"),
-  MATCHING_SERVICE_URL: z.string().url().default("http://localhost:8004"),
-  COLLABORATION_SERVICE_URL: z.string().url().default("http://localhost:8005"),
+  USERS_SERVICE_URL: z.string().url().default("http://users-service"),
+  QUESTIONS_SERVICE_URL: z.string().url().default("http://questions-service"),
+  MATCHING_SERVICE_URL: z.string().url().default("http://matching-service"),
+  COLLABORATION_SERVICE_URL: z
+    .string()
+    .url()
+    .default("http://collaboration-service"),
 });
 
 type EnvSchemaType = z.infer<typeof envSchema>;

--- a/backend/api-gateway/infra/index.ts
+++ b/backend/api-gateway/infra/index.ts
@@ -13,7 +13,7 @@ const memory = config.getNumber("memory") || 128;
 
 // For custom domain
 const subdomain = config.get("subdomain") || "api.staging.";
-const rootDomain = config.get("domainName") || "peerprep.net";
+const rootDomain = config.get("rootDomain") || "peerprep.net";
 
 const hostedZoneId = config.requireSecret("hostedZoneId");
 const domainName = `${subdomain}${rootDomain}`;

--- a/backend/matching-service/app/index.ts
+++ b/backend/matching-service/app/index.ts
@@ -15,8 +15,10 @@ dotenv.config({ path: `.env.development` });
 const app: Application = express();
 const httpServer = createServer(app);
 const io = new Server(httpServer, {
+  path: "/api/matching/websocket",
   cors: {
     origin: process.env.FRONTEND_ORIGIN,
+    credentials: true,
   },
 });
 

--- a/backend/matching-service/infra/Pulumi.prod.yaml
+++ b/backend/matching-service/infra/Pulumi.prod.yaml
@@ -1,5 +1,12 @@
 config:
+  aws:region: ap-southeast-1
   matching-service-infra:acmEcsCertificateArn:
     secure: AAABAGrMpeXHGlicxo6zF5QVCtb0C9Nm645SqxV7V3ZaJXYhqg9t04wLe6VUsAqbc1g13n82tpnoP8kYY8TY5bmxS0yTaGWtMdLLZywUxNOtdNe3DqmBmdixYqG/cf39ABnYirH4GXuKiZFuA9AvHUNM+pbjZ7W+
   matching-service-infra:hostedZoneId:
     secure: AAABAAwc/dn8kJoxze92WxrRvg2bMkBWkFzCPIQi69VlOp3o+zGqpJR65dObSTid18c5qg==
+  matching-service-infra:containerPort: "80"
+  matching-service-infra:cpu: "256"
+  matching-service-infra:memory: "128"
+  matching-service-infra:path: ../app
+  matching-service-infra:rootDomain: peerprep.net
+  matching-service-infra:subdomain: matching.

--- a/backend/matching-service/infra/Pulumi.staging.yaml
+++ b/backend/matching-service/infra/Pulumi.staging.yaml
@@ -1,5 +1,12 @@
 config:
+  aws:region: ap-southeast-1
   matching-service-infra:acmEcsCertificateArn:
     secure: AAABAHXlXYRt2PC4BiUtsGxhicn/22xb2O4py9Yh2wAFQDcDZWXLSITQNCjW/kTEcArrpxSV6YlgoXzpjj30u0KT4UAuNJo8Oumw7BacRA+6sEgZM9GBx4vzmjwEnFD9NMuzRZhY3iyroDvTYAev4UPfrbfYRNde
   matching-service-infra:hostedZoneId:
     secure: AAABAL9rkLIBdNx9DMp4YkfRMcTjYwykfX6TLEBMttZXYnSVKUCnhtReFl0lQgWwoEMqOg==
+  matching-service-infra:containerPort: "80"
+  matching-service-infra:cpu: "256"
+  matching-service-infra:memory: "128"
+  matching-service-infra:path: ../app
+  matching-service-infra:rootDomain: peerprep.net
+  matching-service-infra:subdomain: matching.staging.

--- a/backend/matching-service/infra/index.ts
+++ b/backend/matching-service/infra/index.ts
@@ -13,7 +13,7 @@ const memory = config.getNumber("memory") || 128;
 
 // For custom domain
 const subdomain = config.get("subdomain") || "matching.staging.";
-const rootDomain = config.get("domainName") || "peerprep.net";
+const rootDomain = config.get("rootDomain") || "peerprep.net";
 
 const hostedZoneId = config.requireSecret("hostedZoneId");
 const domainName = `${subdomain}${rootDomain}`;

--- a/backend/question-service/server/infra/index.ts
+++ b/backend/question-service/server/infra/index.ts
@@ -17,7 +17,7 @@ const MONGO_PORT = config.requireSecret("MONGO_PORT");
 
 // For custom domain
 const subdomain = config.get("subdomain") || "questions.staging.";
-const rootDomain = config.get("domainName") || "peerprep.net";
+const rootDomain = config.get("rootDomain") || "peerprep.net";
 
 const hostedZoneId = config.requireSecret("hostedZoneId");
 const domainName = `${subdomain}${rootDomain}`;

--- a/backend/template-service/infra/index.ts
+++ b/backend/template-service/infra/index.ts
@@ -13,7 +13,7 @@ const memory = config.getNumber("memory") || 128;
 
 // For custom domain
 const subdomain = config.get("subdomain") || "template.staging."; // TODO: Update `template` placeholder
-const rootDomain = config.get("domainName") || "peerprep.net";
+const rootDomain = config.get("rootDomain") || "peerprep.net";
 
 const hostedZoneId = config.requireSecret("hostedZoneId");
 const domainName = `${subdomain}${rootDomain}`;

--- a/backend/users-service/infra/index.ts
+++ b/backend/users-service/infra/index.ts
@@ -12,8 +12,8 @@ const cpu = config.getNumber("cpu") || 256;
 const memory = config.getNumber("memory") || 128;
 
 // For custom domain
-const subdomain = config.get("subdomain") || "users.staging."; // TODO: Update `users` placeholder
-const rootDomain = config.get("domainName") || "peerprep.net";
+const subdomain = config.get("subdomain") || "users.staging.";
+const rootDomain = config.get("rootDomain") || "peerprep.net";
 
 const hostedZoneId = config.requireSecret("hostedZoneId");
 const domainName = `${subdomain}${rootDomain}`;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   frontend:
+    container_name: frontend
     build:
       context: ./frontend/app/
       dockerfile: Dockerfile.dev
@@ -12,6 +13,7 @@ services:
       - "8000:5173"
 
   api-gateway:
+    container_name: api-gateway
     build:
       context: ./backend/api-gateway/app/
       dockerfile: Dockerfile.dev
@@ -22,6 +24,7 @@ services:
       - "8001:80"
 
   users-service:
+    container_name: users-service
     build:
       context: ./backend/users-service/app/
       dockerfile: Dockerfile.dev
@@ -32,6 +35,7 @@ services:
       - "8002:80"
 
   question-service-server:
+    container_name: question-service-server
     build:
       context: ./backend/question-service/server/app/
       dockerfile: Dockerfile.dev
@@ -47,6 +51,7 @@ services:
       - "8003:80"
 
   question-service-db:
+    container_name: question-service-db
     image: mongo:latest
     volumes:
       - question-service-db-data:/data/db
@@ -60,6 +65,7 @@ services:
       start_period: 40s
 
   matching-service:
+    container_name: matching-service
     build:
       context: ./backend/matching-service/app/
       dockerfile: Dockerfile.dev
@@ -70,6 +76,7 @@ services:
       - "8004:80"
 
   # template-service:
+  #   container_name: template-service
   #   build:
   #     context: ./backend/template-service/app/
   #     dockerfile: Dockerfile.dev

--- a/frontend/app/.env.development
+++ b/frontend/app/.env.development
@@ -1,1 +1,0 @@
-VITE_BACKEND_URL=http://localhost:8001

--- a/frontend/app/.env.development
+++ b/frontend/app/.env.development
@@ -1,2 +1,1 @@
 VITE_BACKEND_URL=http://localhost:8001
-VITE_MATCHING_SERVICE_URL=http://localhost:8004

--- a/frontend/app/.env.example
+++ b/frontend/app/.env.example
@@ -1,2 +1,1 @@
 VITE_BACKEND_URL=http://localhost:8001
-VITE_MATCHING_SERVICE_URL=http://localhost:8004

--- a/frontend/app/src/constants/api.ts
+++ b/frontend/app/src/constants/api.ts
@@ -16,3 +16,11 @@ export const API_ENDPOINT = {
   AUTH_GITHUB_AUTH_URL: "/auth/github/authorize",
   AUTH_GITHUB_LOGIN: "/auth/github/login",
 } as const;
+
+/**
+ * Websocket paths
+ */
+export const WEBSOCKET_PATH = {
+  MATCHING: "/api/matching/websocket",
+  COLLABORATION: "/api/collaboration/websocket",
+} as const;

--- a/frontend/app/src/lib/env.ts
+++ b/frontend/app/src/lib/env.ts
@@ -2,7 +2,6 @@ import zod from "zod";
 
 const envSchema = zod.object({
   VITE_BACKEND_URL: zod.string().url().nonempty(),
-  VITE_MATCHING_SERVICE_URL: zod.string().url().nonempty(),
 });
 
 export const env = envSchema.parse(import.meta.env);

--- a/frontend/app/src/pages/home/join.tsx
+++ b/frontend/app/src/pages/home/join.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Socket, io } from "socket.io-client";
-
 import { Page } from "@/components";
 import { MATCHING_EVENTS } from "@/constants/matching";
 import { ROUTE } from "@/constants/route";
@@ -9,6 +8,7 @@ import { FindingMatchCard, SelectPreferencesCard } from "@/features/matching";
 import { useAuth } from "@/hooks";
 import { env } from "@/lib/env";
 import { Preferences, matchingSchema } from "@/types/matching";
+import { WEBSOCKET_PATH } from "@/constants/api";
 
 function JoinPage() {
   const { data } = useAuth();
@@ -19,8 +19,10 @@ function JoinPage() {
 
   const joinRoom = async (preferences: Preferences) => {
     if (socketRef.current == null) {
-      // TODO: make connection through API gateway URL
-      socketRef.current = io(env.VITE_MATCHING_SERVICE_URL);
+      socketRef.current = io(env.VITE_BACKEND_URL, {
+        path: WEBSOCKET_PATH.MATCHING,
+        withCredentials: true,
+      });
     }
 
     const { current: socket } = socketRef;

--- a/frontend/infra/index.ts
+++ b/frontend/infra/index.ts
@@ -12,7 +12,7 @@ const indexDocument = config.get("indexDocument") || "index.html";
 // For custom domain
 const subdomainConfig = config.get("subdomain");
 const subdomain = subdomainConfig !== undefined ? subdomainConfig : "staging."; // As 'subdomain' can be defined as an empty string for prod
-const rootDomain = config.get("domainName") || "peerprep.net";
+const rootDomain = config.get("rootDomain") || "peerprep.net";
 
 const hostedZoneId = config.requireSecret("hostedZoneId");
 const domainName = `${subdomain}${rootDomain}`;


### PR DESCRIPTION
things achieved in this PR:

- [x] ran the matching service websocket thru the API gateway 
- [x] fixed API gateway `.env.example` (from the port numbers to the docker compose service names - this is because the API gateway container communicates to the other service containers not via the host network but thru inter container communications)
- [x] standardized Pulumi stacks to use `rootDomain` instead of `domainName` 
- [x] fixed matching service Pulumi missing configs