### PR TITLE
Feat: Update Question Service endpoints for questions portal

### DIFF
--- a/backend/question-service/server/app/core/database.py
+++ b/backend/question-service/server/app/core/database.py
@@ -30,3 +30,7 @@ client = connect_to_mongo(MONGO_CONNECTION_STRING)
 print("Successfully connected to MongoDB!")
 db = client['questions_db']
 collection = db['problems']
+
+# Create a text index on the title and description fields
+collection.create_index([("title", "text"), ("description", "text")])
+

--- a/backend/question-service/server/app/readme.md
+++ b/backend/question-service/server/app/readme.md
@@ -104,7 +104,67 @@ docker run -p 8000:80 question-service
     }
     ```
 
-2. `GET /api/questions/all` Get All Questions
+2. `GET /api/questions/view` Retrieve Questions with Pagination, Filtering and Sorting
+
+    - **Description**: Retrieve questions with optional sorting and pagination. Used for question portal view.
+    - **Query Parameters**:
+        - `page`: Page number for pagination. Starts from 0. Default is 0.
+        - `limit`: Number of items to retrieve per page. Default is 10.
+        - `sort_by`: Field to sort by (e.g., `title`). Default is `id`.
+        - `order`: Order of sorting. Use 'asc' for ascending and 'desc' for descending. Default is `asc`.
+        - `difficulty` (list of strings, optional): Allows users to filter questions by their difficulty levels. Accepts a list of difficulty values.
+        - `topic` (list of strings, optional): Enables users to filter questions based on specific topics.
+        - `category` (list of strings, optional): Lets users filter questions by their categories.
+        - `paid_only` (boolean, optional): When set to `true`, only questions that are paid will be returned. When set to `false`, only free questions will be returned.
+        - `search` (string, optional): A search string that will be used to match questions. Questions with titles or descriptions that contain the search string will be returned.
+
+**Sample Request**:
+
+```http
+GET /api/questions/view?page=1&limit=5&sort_by=title&order=desc&difficulty=Easy&difficulty=Medium&topic=Array&search=Sum
+```
+
+**Sample Response**:
+
+```json
+{
+    "status": "success",
+    "data": {
+        "questions": [
+            {
+                "id": "1",
+                "title": "Two Sum",
+                ...
+            },
+            {
+                "id": "2",
+                "title": "Three Sum",
+                ...
+            }
+        ],
+    "pagination": {
+        "current_page":1,
+        "limit":5,
+        "sort_by":"title",
+        "order":"desc",
+        "total_questions":20,
+        "total_pages":4
+        },
+    "filters": {
+        "difficulty": [
+            "Easy",
+            "Medium"
+            ],
+        "topic":[
+            "Array"
+            ],
+        "search": "Sum"
+        }
+    }
+}
+```
+
+3. `GET /api/questions/all` Get All Questions
 
     - **Description**: Returns a list of all questions with all fields.
 
@@ -140,7 +200,7 @@ docker run -p 8000:80 question-service
     }
     ```
 
-3. `GET /api/questions/{question_id}` Get a Single Question
+4. `GET /api/questions/{question_id}` Get a Single Question
 
     - **Description**: Returns a single question matching the given id.
     - **Path Parameters**:
@@ -169,7 +229,7 @@ docker run -p 8000:80 question-service
     }
     ```
 
-4. `GET /api/questions/filters` Get Question Filters
+5. `GET /api/questions/filters` Get Question Filters
 
     - **Description**: Returns a list of all possible filters for questions: Difficulty and Topic.
 
@@ -227,52 +287,7 @@ docker run -p 8000:80 question-service
     }
     ```
 
-2. `GET /api/admin/questions` Retrieve Questions with Pagination and Sorting
-
-    - **Description**: Retrieve questions with optional sorting and pagination. Used for admin portal view.
-    - **Query Parameters**:
-        - `page`: Page number for pagination. Starts from 0. Default is 0.
-        - `limit`: Number of items to retrieve per page. Default is 10.
-        - `sort_by`: Field to sort by (e.g., `title`). Default is `id`.
-        - `order`: Order of sorting. Use 'asc' for ascending and 'desc' for descending. Default is `asc`.
-
-    **Sample Request**:
-
-    ```
-    GET /api/admin/questions?page=1&limit=5&sort_by=title&order=desc
-    ```
-
-    **Sample Response**:
-
-    ```json
-    {
-        "status": "success",
-        "data": {
-            "questions": [
-                {
-                    "id": "5",
-                    "title": "Z Reverse Array",
-                    ...
-                },
-                {
-                    "id": "4",
-                    "title": "Y Find Maximum in Array",
-                    ...
-                }
-            ],
-        "pagination" = {
-            "current_page": 0, # Page number starts from 0 (0-indexed)
-            "limit": 10,
-            "sort_by": "id",
-            "order": "asc",
-            "total_questions": 20,
-            "total_pages": 1, # Total number of pages (0-indexed)
-    }
-        }
-    }
-    ```
-
-3. `PUT /api/admin/questions/{question_id}` Update an Existing Question
+2. `PUT /api/admin/questions/{question_id}` Update an Existing Question
 
     - **Description**: Updates an existing question in the database.
     - **Path Parameters**:
@@ -303,7 +318,7 @@ docker run -p 8000:80 question-service
     }
     ```
 
-4. `DELETE /api/admin/questions/{question_id}` Delete a Question
+3. `DELETE /api/admin/questions/{question_id}` Delete a Question
 
     - **Description**: Deletes a question from the database.
     - **Path Parameters**:

--- a/backend/question-service/server/app/routers/admin.py
+++ b/backend/question-service/server/app/routers/admin.py
@@ -1,7 +1,5 @@
-from fastapi import HTTPException, Query, APIRouter
-from typing import Optional
+from fastapi import HTTPException, APIRouter
 import sys
-import math
 
 sys.path.append("..")
 from core.database import collection
@@ -35,55 +33,6 @@ async def create_question(question: dict):
     question["_id"] = str(question["_id"])
 
     return jsend_response(JSendStatus.SUCCESS, {"question": question})
-
-
-@admin_router.get("/questions")
-async def get_questions(
-    page: int = Query(
-        0, description="Page number for pagination. Starts from 0."),
-    limit: int = Query(
-        10, description="Number of items to retrieve per page."),
-    sort_by: Optional[str] = Query(
-        "id", description="Field to sort by. E.g., 'title'."),
-    order: Optional[str] = Query(
-        "asc", description="Order of sorting. Use 'asc' for ascending and 'desc' for descending.")
-):
-    """
-    Retrieve questions with optional sorting and pagination. Used for admin portal view.
-    """
-    # Basic validation for order
-    if order not in ["asc", "desc"]:
-        raise HTTPException(
-            status_code=400, detail="Invalid order value. Use 'asc' or 'desc'.")
-
-    # Create the sort order
-    sort_order = 1 if order == "asc" else -1
-
-    # If sort_by is provided, use it for sorting
-    sort_data = [(sort_by, sort_order)] if sort_by else [("id", sort_order)]
-
-    # Fetch data from MongoDB with sorting and pagination
-    cursor = collection.find({}, {"_id": False}).sort(
-        sort_data).skip(page * limit).limit(limit)
-    questions = list(cursor)
-
-    if not questions or len(questions) == 0:
-        raise HTTPException(status_code=404, detail="No questions found.")
-
-    # Add pagination metadata
-    total_questions = collection.count_documents({})
-    total_pages = math.ceil(total_questions / limit)
-    pagination = {
-        "current_page": page,
-        "limit": limit,
-        "sort_by": sort_by,
-        "order": order,
-        "total_questions": total_questions,
-        "total_pages": total_pages,
-    }
-
-    return jsend_response(JSendStatus.SUCCESS, {"questions": questions, "pagination": pagination})
-
 
 @admin_router.put("/questions/{question_id}")
 async def update_question(question_id: int, updated_data: dict):

--- a/backend/question-service/server/app/routers/questions.py
+++ b/backend/question-service/server/app/routers/questions.py
@@ -1,4 +1,5 @@
-from typing import Annotated, Union
+import math
+from typing import Annotated, Optional, Union
 from fastapi import APIRouter, Query, HTTPException
 import sys
 
@@ -38,6 +39,80 @@ async def get_questions(
 
     return jsend_response(JSendStatus.SUCCESS, {"questions": questions})
 
+@questions_router.get("/view")
+async def get_questions(
+    page: int = Query(1, description="Page number for pagination. Starts from 1."),
+    limit: int = Query(10, description="Number of items to retrieve per page."),
+    sort_by: Optional[str] = Query("id", description="Field to sort by. E.g., 'title'."),
+    order: Optional[str] = Query("asc", description="Order of sorting. Use 'asc' for ascending and 'desc' for descending."),
+    difficulty: Annotated[Union[list[str], None], Query(description="Filter by difficulty")] = None,
+    topic: Annotated[Union[list[str], None], Query(description="Filter by topic")] = None,
+    category: Annotated[Union[list[str], None], Query(description="Filter by category")] = None,
+    paid_only: Optional[bool] = Query(None, description="Filter by paid status. Use a boolean value. Eg. 'true', 'True', 1 for True and 'false', 'False', 0 for False."),
+    search: Optional[str] = Query(None, description="Search string for questions.")
+):
+    """
+    Retrieve questions with optional sorting, pagination, search query and filters. Used for question portal view.
+    """
+    # Basic validation for order
+    if order not in ["asc", "desc"]:
+        raise HTTPException(status_code=400, detail="Invalid order value. Use 'asc' or 'desc'.")
+
+    # Create the sort order
+    sort_order = 1 if order == "asc" else -1
+
+    # If sort_by is provided, use it for sorting
+    sort_data = [(sort_by, sort_order)] if sort_by else [("id", sort_order)]
+
+    # Get skip count
+    skip_count = (page - 1) * limit
+
+    # Build the MongoDB query with filters
+    query = {}
+    if category:
+        query["category"] = {"$in": category}
+    if difficulty:
+        query["difficulty"] = {"$in": difficulty}
+    if topic:
+        query["topic_tags"] = {"$in": topic}
+    if paid_only is not None:
+        query["paid_only"] = paid_only
+    if search:
+        query["$text"] = {"$search": search}
+
+    # Fetch data from MongoDB with sorting, pagination, and filters
+    cursor = collection.find(query, {"_id": False}).sort(sort_data).skip(skip_count).limit(limit)
+    questions = list(cursor)
+
+    if not questions or len(questions) == 0:
+        raise HTTPException(status_code=404, detail="No questions found.")
+
+    # Add pagination metadata
+    total_questions = collection.count_documents(query)
+    total_pages = math.ceil(total_questions / limit)
+    pagination = {
+        "current_page": page,
+        "limit": limit,
+        "sort_by": sort_by,
+        "order": order,
+        "total_questions": total_questions,
+        "total_pages": total_pages,
+    }
+
+    # Add filters metadata
+    filters = {}
+    if category:
+        filters["category"] = category
+    if difficulty:
+        filters["difficulty"] = difficulty
+    if topic:
+        filters["topic"] = topic
+    if paid_only is not None:
+        filters["paid_only"] = paid_only
+    if search:
+        filters["search"] = search
+
+    return jsend_response(JSendStatus.SUCCESS, {"questions": questions, "pagination": pagination, "filters": filters})
 
 @questions_router.get("/all")
 async def get_all_questions():


### PR DESCRIPTION
- Add Text index to question title and description (for search query string)

- Shift `/api/admin/questions` to `/api/questions/view` for all users to use table form
    - Add Filters for Topic, Category, Difficulty, Paid_only 
    - Add Search string filter to query for questions with titles or descriptions that contain search query string
    - Change page number and total pages to follow 1-indexing for easier tabular access
    - Add `filters` metadata to response body

- Update readme.md to reflect above API changes